### PR TITLE
OTHER: Use signed ints with boost::get<>

### DIFF
--- a/backend_xmmsclient++/xclient.cpp
+++ b/backend_xmmsclient++/xclient.cpp
@@ -166,7 +166,7 @@ XClient::dictToQHash (const std::string &key,
 		             QVariant (boost::get< int32_t > (value)));
 	} else if (value.type () == typeid (uint32_t)) {
 		hash.insert (QString::fromLatin1 (key.c_str ()),
-		             QVariant (boost::get< uint32_t > (value)));
+		             QVariant (boost::get< int32_t > (value)));
 	} else {
 		QString val;
 		val = QString::fromUtf8 (boost::get< std::string > (value).c_str ());
@@ -220,7 +220,7 @@ XClient::propDictToQHash (const std::string &key,
 		             QVariant (boost::get< int32_t > (value)));
 	} else if (value.type () == typeid (uint32_t)) {
 		hash.insert (QString::fromLatin1 (key.c_str ()),
-		             QVariant (boost::get< uint32_t > (value)));
+		             QVariant (boost::get< int32_t > (value)));
 	} else {
 		QString val;
 		if (key == "url") {

--- a/src/BrowseModel.cpp
+++ b/src/BrowseModel.cpp
@@ -129,7 +129,7 @@ BrowseModel::list_cb (const Xmms::List< Xmms::Dict > &res)
 					name += " - ";
 				}
 				if (d.contains ("tracknr")) {
-					name += QString::number (d.get<uint32_t>
+					name += QString::number (d.get<int32_t>
 											 ("tracknr")).rightJustified(2, '0');
 					name += " - ";
 				}


### PR DESCRIPTION
This fixes a compile-time error with recent Boost versions.
